### PR TITLE
Added screen sleep protection while mining

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/WebDollar/User-Interface-WebDollar#readme",
   "dependencies": {
     "clipboard": "^1.7.1",
+    "nosleep.js": "^0.9.0",
     "uuid": "^3.2.1",
     "v-clipboard": "*",
     "vue": "^2.5.13",

--- a/src/components/Mining/slider.vue
+++ b/src/components/Mining/slider.vue
@@ -36,11 +36,11 @@
         methods: {
             change(value) {
                 if (value > 0) {
-                    console.log('Enabled screen sleep prevention.')
                     this.noSleep.enable();
+                    console.log('Enabled screen sleep prevention.')
                 } else {
-                    console.log('Disabled screen sleep prevention.')
                     this.noSleep.disable();
+                    console.log('Disabled screen sleep prevention.')
                 }
                 this.$emit('sliderChanged', value);
             },

--- a/src/components/Mining/slider.vue
+++ b/src/components/Mining/slider.vue
@@ -10,6 +10,8 @@
 <script>
 
     import vueSlider from 'vue-slider-component';
+    import * as NoSleep from 'nosleep.js/dist/NoSleep';
+
 
     export default {
 
@@ -22,32 +24,24 @@
         data() {
             return {
                 value: localStorage.getItem("miner-settings-worker-count") || 0,
-                disabled:true,
+                disabled: false,
                 screenWidth: window.innerWidth,
                 logicalProcessors: window.navigator.hardwareConcurrency === undefined ? 4 : window.navigator.hardwareConcurrency * 1,
                 sliderMobileWidth: 200,
                 disableHalving: false,
+                noSleep: new NoSleep()
             }
         },
 
         methods: {
             change(value) {
-
-                console.log("value", value);
-
-                //TODO use halver
-
-//                if (this.disableHalving)
-//                    this.$refs['slider'].setValue(value);
-//                else
-//                    if (value > (this.value||1) *3){
-//
-//                        value = (this.value||1) *3;
-//                        this.$refs['slider'].setValue(value);
-//                        return;
-//
-//                    }
-
+                if (value > 0) {
+                    console.log('Enabled screen sleep prevention.')
+                    this.noSleep.enable();
+                } else {
+                    console.log('Disabled screen sleep prevention.')
+                    this.noSleep.disable();
+                }
                 this.$emit('sliderChanged', value);
             },
             addEvent(object, type, callback) {

--- a/src/components/Mining/slider.vue
+++ b/src/components/Mining/slider.vue
@@ -24,7 +24,7 @@
         data() {
             return {
                 value: localStorage.getItem("miner-settings-worker-count") || 0,
-                disabled: false,
+                disabled: true,
                 screenWidth: window.innerWidth,
                 logicalProcessors: window.navigator.hardwareConcurrency === undefined ? 4 : window.navigator.hardwareConcurrency * 1,
                 sliderMobileWidth: 200,


### PR DESCRIPTION
Whenever mining power is enabled, the mobile screen will not sleep anymore.
Sleeping prevents it from mining. This has been tested on older and newer iOS devices and several Android phones.